### PR TITLE
Free the loaded library at shutdown

### DIFF
--- a/src/JABWrapper/jab_wrapper.py
+++ b/src/JABWrapper/jab_wrapper.py
@@ -23,6 +23,8 @@ from ctypes import (
     create_unicode_buffer
 )
 
+from _ctypes import FreeLibrary
+
 from typing import Callable, List, Tuple
 
 from JABWrapper.jab_types import (
@@ -195,9 +197,14 @@ class JavaAccessBridgeWrapper:
         self._context_callbacks: dict[str, List[Callable[[JavaObject], None]]] = dict()
 
     def shutdown(self):
+        # Call at the end to execution to free memory and unload the
+        # windows wrapper.dll
         self._context_callbacks = dict()
         if not self.ignore_callbacks:
             self._remove_callbacks()
+        if self._wab and self._wab._handle:
+            FreeLibrary(self._wab._handle)
+            del self._wab
 
     def _define_functions(self) -> None:
         # void Windows_run()


### PR DESCRIPTION
There has been cases where a python error is raised from the main thread where java-access-bridge-wrapper has been imported. To tackle this it would be safer to manually unload the .dll library to make sure the memory is free and no exceptions from the java application is causing issues in the access bridge user side.

There is unfortunately no direct way to unload or free the loaded .dll library within the same Python process. The library will be unloaded automatically when the Python process terminates.

There is an API in the _ctypes implementation side for freeing a loaded library, but the ctypes library should be considerer as the public API and it doesn't expose it.

I'll leave this PR open if this is needed later to be merged to fix the error cases.